### PR TITLE
drop python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            python-version: [3.6, 3.7, 3.8, 3.9]
+            python-version: [3.7, 3.8, 3.9]
             os: [macOs-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
@looooo brauchen wir noch python 3.6?