### PR TITLE
Fix meshpy 2020.1 import

### DIFF
--- a/openglider/mesh/meshpy_triangle.py
+++ b/openglider/mesh/meshpy_triangle.py
@@ -2,7 +2,7 @@ from __future__ import division
 from __future__ import absolute_import
 from meshpy.triangle import MeshInfo
 
-import meshpy._triangle as internals
+import meshpy._internals as internals
 
 
 def custom_triangulation(mesh_info, opts=""):


### PR DESCRIPTION
It's no  meshpy._triangle in meshpy now;