### PR TITLE
Remove Unused Dependency: lxml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     - conda config --add channels conda-forge
     - conda update -q conda
     - conda info -a
-    - conda create -q -n test-environment python=$PY_VERSION ezdxf ezodf lxml meshpy numpy svgwrite coveralls flake8
+    - conda create -q -n test-environment python=$PY_VERSION ezdxf ezodf meshpy numpy svgwrite coveralls flake8
     - source activate test-environment
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
     - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ setup(
                     "scipy",
                     "ezdxf",
                     "ezodf",
-                    "lxml", # missing in ezodf:q;
                     "pyexcel-ods",
                     "meshpy"
                     ],


### PR DESCRIPTION
## Summary

Hello @looooo,

I hope you're doing well! I've just opened this pull request that proposes the removal of the unused `lxml` dependency from the `setup.py` configuration file. It's part of an ongoing research endeavor focusing on the identification and elimination of code bloat within software projects. Your insights on this would be really valuable.

## Rationale

The `lxml` library was introduced  in  6f6a83a. However it appears to be unused in the source code. It was added on the grounds that it was required indirectly by `ezodf`. However,  it is already listed in `ezodf`s [dependencies](https://github.com/T0ha/ezodf/blob/f9675c165679290a15bd2f9ab75f90fbc1490668/setup.py#L40), making its declaration in `OpenGlider` redundant. 

Instead, when `OpenGlider` is installed through pip (e.g. `pip install -e .`), pip will automatically resolve `lxml` through `ezodf`.

Removing this unused dependency will  mitigate potential security risks and, most importantly, simplify the dependency management process.

## Changes

- Removed the `lxml`  dependency from the `setup.py` file.
- Updated `.travis.yaml` to reflect on this change

## Impact

- Reduced package size: Eliminating this unused dependency will decrease the overall size of the installed packages.

- Simplified dependency tree: A leaner list of dependencies aids in more straightforward project maintenance and faster installations.

